### PR TITLE
fix(installation): Be more precise with calls into go-swagger.

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -277,6 +277,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c9cbcff037e702a47ac857d029541914dd60c4cd2813688db89154bbbfb956b5"
+  inputs-digest = "0027bc11e78ad21a93ea99e48d759ec2a3bbbf700cf41f3d162ad0914bc6508a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/jessevdk/go-flags"
-  version = "1.4.0"
+  version = "1.3.0"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
Previously when attempting to install via `go get`, the go compiler
would report a type error. This was due to the fact that `go-swagger`
includes a `vendor` directory, and expects to be used as a utility, not
as a library. Go prevents explicit imports from `vendor` paths, so
instead we make a more precise call into the `go-swagger` machinery,
calling the scanner and marshalling the result to JSON ourselves to
avoid writing the type.

/shrug #yolo